### PR TITLE
feat: 로그인 기능 추가

### DIFF
--- a/src/main/java/com/hyeinyeo/toy_spring_board/constants/SessionConst.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/constants/SessionConst.java
@@ -1,0 +1,5 @@
+package com.hyeinyeo.toy_spring_board.constants;
+
+public interface SessionConst {
+    public static final String LOGIN_USER = "loginUser";
+}

--- a/src/main/java/com/hyeinyeo/toy_spring_board/controller/login/LoginController.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/controller/login/LoginController.java
@@ -1,0 +1,66 @@
+package com.hyeinyeo.toy_spring_board.controller.login;
+
+import com.hyeinyeo.toy_spring_board.constants.SessionConst;
+import com.hyeinyeo.toy_spring_board.domain.User;
+import com.hyeinyeo.toy_spring_board.form.login.LoginForm;
+import com.hyeinyeo.toy_spring_board.service.login.LoginService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class LoginController {
+    private final LoginService loginService;
+
+    @GetMapping("/login")
+    public String loginForm(@ModelAttribute("loginForm") LoginForm form)  {
+        return "/login/loginForm";
+    }
+
+    @PostMapping("/login")
+    public String login(@Validated @ModelAttribute LoginForm form,
+                        BindingResult bindingResult,
+                        @RequestParam(defaultValue = "/articles") String redirectURL,
+                        HttpServletRequest request){
+        // 입력 검증
+        if (bindingResult.hasErrors()) {
+            log.info("Login form validation error: {}", bindingResult.getAllErrors());
+            return "login/loginForm";
+        }
+
+        // 로그인 서비스 로직
+        User loginUser = loginService.login(form.getLoginId(), form.getPassword());
+
+        // 로그인 실패
+        if (loginUser == null) {
+            bindingResult.reject("login.failed", "아이디 또는 비밀번호가 맞지 않습니다.");
+            return "login/loginForm";
+        }
+
+        // 로그인 성공 및 리다이렉션
+        HttpSession session = request.getSession();
+        session.setAttribute(SessionConst.LOGIN_USER, loginUser);
+        log.info("Login successful: {}", loginUser);
+        log.info("Login session: {}", session.getId());
+        return "redirect:" + redirectURL;
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        return "redirect:/";
+    }
+}

--- a/src/main/java/com/hyeinyeo/toy_spring_board/form/login/LoginForm.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/form/login/LoginForm.java
@@ -1,0 +1,13 @@
+package com.hyeinyeo.toy_spring_board.form.login;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginForm {
+    @NotBlank
+    private String loginId;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/hyeinyeo/toy_spring_board/service/login/LoginService.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/service/login/LoginService.java
@@ -1,0 +1,8 @@
+package com.hyeinyeo.toy_spring_board.service.login;
+
+import com.hyeinyeo.toy_spring_board.domain.User;
+
+public interface LoginService {
+    // 패스워드 일치하면 User 객체 반환
+    User login(String loginId, String password);
+}

--- a/src/main/java/com/hyeinyeo/toy_spring_board/service/login/LoginServiceImpl.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/service/login/LoginServiceImpl.java
@@ -1,0 +1,29 @@
+package com.hyeinyeo.toy_spring_board.service.login;
+
+import com.hyeinyeo.toy_spring_board.domain.User;
+import com.hyeinyeo.toy_spring_board.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LoginServiceImpl implements LoginService {
+    private final UserRepository userRepository;
+
+    @Override
+    public User login(String loginId, String password) {
+        try{
+            return userRepository.findByLoginId(loginId)
+                    .filter(m -> m.getPassword().equals(password))
+                    .orElse(null); // 있는 loginId이지만 패스워드가 맞지 않을 때
+        } catch (DataAccessException e){ // 없는 loginId일 때
+            log.info("예외 발생: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/resources/templates/login/loginForm.html
+++ b/src/main/resources/templates/login/loginForm.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Bootstrap CDN -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+  <style>
+    .form-container {
+      max-width: 400px;
+      margin: 0 auto;
+      padding: 2rem;
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+      border-radius: 10px;
+      background-color: white;
+    }
+
+    .form-control:focus {
+      box-shadow: none;
+      border-color: #2C3E50;
+    }
+
+    .btn-custom {
+      background-color: #2C3E50;
+      color: white;
+      border-radius: 5px;
+      padding: 8px 30px;
+      transition: all 0.3s ease;
+    }
+
+    .btn-custom:hover {
+      background-color: #34495E;
+      transform: translateY(-2px);
+      box-shadow: 0 4px 15px rgba(44, 62, 80, 0.2);
+    }
+
+    .page-title {
+      color: #2c3e50;
+      font-weight: 600;
+      margin-bottom: 2rem;
+      text-align: center;
+    }
+    .field-error {
+      border-color: #dc3545;
+      color: #dc3545;
+    }
+  </style>
+</head>
+<body class="bg-light">
+
+<div class="container py-5">
+  <!-- 로그인 폼 -->
+  <div class="form-container">
+    <h2 class="page-title">로그인</h2>
+
+    <form th:action method="post" th:object="${loginForm}">
+      <div th:if="${#fields.hasGlobalErrors()}">
+        <p class="field-error" th:each="err : ${#fields.globalErrors()}"
+           th:text="${err}"> 로그인 오류 메시지</p>
+      </div>
+
+      <div class="mb-3">
+        <label for="loginId" class="form-label">아이디</label>
+        <input type="text" class="form-control" id="loginId" th:field="*{loginId}"
+               th:errorclass="field-error">
+        <div class="field-error" th:errors="*{loginId}"> 아이디 오류 </div>
+      </div>
+
+      <div class="mb-4">
+        <label for="password" class="form-label">패스워드</label>
+        <input type="password" class="form-control" id="password" th:field="*{password}"
+               th:errorclass="field-error">
+        <div class="field-error" th:errors="*{password}"> 패스워드 오류 </div>
+      </div>
+
+      <div class="d-grid gap-2">
+        <button type="submit" class="btn btn-custom">확인</button>
+        <button type="button" class="btn btn-secondary"
+                onclick="location.href='home.html'"
+                th:onclick="|location.href='@{/}'|">취소</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## 작동 사진/영상
- 로그인 폼(테스트 데이터 입력 상태)
![image](https://github.com/user-attachments/assets/e0bbdd92-168a-4df4-a4ac-4d0c593b9388)

- 로그인 입력 검증
  - @ Validated 입력 검증
  ![image](https://github.com/user-attachments/assets/0f43c09d-feba-400a-9302-9ddfa4a02bbc)
  - 없는 회원 정보일 때
  ![image](https://github.com/user-attachments/assets/37dca92a-7106-4f44-9855-231931e93afb)

- 로그인 성공
  - default: /articles로 리다이렉션
  - 이전에 요청한 페이지로 리다이렉션

## 주요 변경사항
- 로그인 및 로그아웃 기능 추가 (세션 사용)

## 부가 변경사항
- 로그인 컨트롤러
- 로그인 서비스 인터페이스 및 구현체
- 로그인폼 클래스
- 로그인폼 템플릿
- 세션 키 Const 클래스

## 참고 링크

## 리뷰어에게

## etc.
- 추후 로그인 인터셉터 추가 예정
- OAuth 2.0 도입 예정
