### PR TITLE
refactor: repository의 하위 패키지 user 추가 및 UserRepository 이동

### DIFF
--- a/src/main/java/com/hyeinyeo/toy_spring_board/repository/user/MemoryUserRepository.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/repository/user/MemoryUserRepository.java
@@ -1,4 +1,4 @@
-package com.hyeinyeo.toy_spring_board.repository;
+package com.hyeinyeo.toy_spring_board.repository.user;
 
 import com.hyeinyeo.toy_spring_board.domain.User;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/com/hyeinyeo/toy_spring_board/repository/user/UserRepository.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/repository/user/UserRepository.java
@@ -1,4 +1,4 @@
-package com.hyeinyeo.toy_spring_board.repository;
+package com.hyeinyeo.toy_spring_board.repository.user;
 
 import com.hyeinyeo.toy_spring_board.domain.User;
 

--- a/src/main/java/com/hyeinyeo/toy_spring_board/service/login/LoginServiceImpl.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/service/login/LoginServiceImpl.java
@@ -1,7 +1,7 @@
 package com.hyeinyeo.toy_spring_board.service.login;
 
 import com.hyeinyeo.toy_spring_board.domain.User;
-import com.hyeinyeo.toy_spring_board.repository.UserRepository;
+import com.hyeinyeo.toy_spring_board.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;

--- a/src/main/java/com/hyeinyeo/toy_spring_board/service/register/RegisterServiceImpl.java
+++ b/src/main/java/com/hyeinyeo/toy_spring_board/service/register/RegisterServiceImpl.java
@@ -5,7 +5,7 @@ import com.hyeinyeo.toy_spring_board.dto.register.SavedUserResponseDto;
 import com.hyeinyeo.toy_spring_board.dto.register.UserRegiSuccessDto;
 import com.hyeinyeo.toy_spring_board.form.register.UserRegistrationForm;
 import com.hyeinyeo.toy_spring_board.mapper.user.RegisterMapper;
-import com.hyeinyeo.toy_spring_board.repository.UserRepository;
+import com.hyeinyeo.toy_spring_board.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
## 작동 사진/영상
- 변경 전
![image](https://github.com/user-attachments/assets/254dc2c3-32d1-4b15-bf14-d7c0f2eeed21)

- 변경 후
![image](https://github.com/user-attachments/assets/36fe5b36-aab8-4d7f-90a4-7b281765fc54)


## 주요 변경사항
- repository 패키지 내에 user 서브패키지를 추가하여 구조 정리
- UserRepository 인터페이스 및 MemoryUserRepository 클래스 이동

## 부가 변경사항
- 관련된 클래스(LoginServiceImpl.java, RegisterServiceImpl.java)의 import 및 코드 수정


## 참고 링크

## 리뷰어에게

## etc.